### PR TITLE
Flang: Add support for Cray pointers in OpenMP constructs

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2242,16 +2242,22 @@ void OmpAttributeVisitor::Post(const parser::Name &name) {
       if (Symbol * found{currScope().FindSymbol(name.source)}) {
         if (symbol != found) {
           name.symbol = found; // adjust the symbol within region
-        } else if (GetContext().defaultDSA == Symbol::Flag::OmpNone &&
-            !symbol->test(Symbol::Flag::OmpThreadprivate) &&
-            // Exclude indices of sequential loops that are privatised in
-            // the scope of the parallel region, and not in this scope.
-            // TODO: check whether this should be caught in IsObjectWithDSA
-            !symbol->test(Symbol::Flag::OmpPrivate)) {
-          context_.Say(name.source,
-              "The DEFAULT(NONE) clause requires that '%s' must be listed in "
-              "a data-sharing attribute clause"_err_en_US,
-              symbol->name());
+        } else {
+          // If the symbol is a CrayPointee, no need to updates the symbol
+          // flags.
+          if (symbol->test(Symbol::Flag::CrayPointee)) {
+            return;
+          } else if (GetContext().defaultDSA == Symbol::Flag::OmpNone &&
+              !symbol->test(Symbol::Flag::OmpThreadprivate) &&
+              // Exclude indices of sequential loops that are privatised in
+              // the scope of the parallel region, and not in this scope.
+              // TODO: check whether this should be caught in IsObjectWithDSA
+              !symbol->test(Symbol::Flag::OmpPrivate)) {
+            context_.Say(name.source,
+                "The DEFAULT(NONE) clause requires that '%s' must be listed in "
+                "a data-sharing attribute clause"_err_en_US,
+                symbol->name());
+          }
         }
       }
     }

--- a/flang/test/Semantics/OpenMP/cray-pointer-usage.f90
+++ b/flang/test/Semantics/OpenMP/cray-pointer-usage.f90
@@ -1,0 +1,29 @@
+!RUN: %python %S/../test_errors.py %s %flang -fopenmp
+subroutine test_crayptr
+  implicit none
+  integer :: I
+  real*8 var(*)
+  pointer(ivar,var)
+  real*8 pointee(8)
+
+  pointee(1) = 42.0
+  ivar = loc(pointee)
+
+  !$omp parallel num_threads(2) default(none) shared(ivar)
+    print *, var(1)
+  !$omp end parallel
+
+  !$omp parallel num_threads(2) default(none) private(ivar)
+    print *, var(1)
+  !$omp end parallel
+
+  !$omp parallel num_threads(2) default(private) shared(ivar)
+    print *, var(1)
+  !$omp end parallel
+
+  !$omp parallel num_threads(2) default(firstprivate) shared(ivar)
+    print *, var(1)
+  !$omp end parallel
+
+end subroutine test_crayptr
+


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added test case for Cray pointer usage in OpenMP parallel regions.

- **Tests**
	- Introduced a new test subroutine `test_crayptr` demonstrating Cray pointer behavior with different OpenMP sharing attributes.

- **Bug Fixes**
	- Improved handling of Cray pointers in OpenMP construct resolution to prevent unintended symbol flag updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->